### PR TITLE
disable registry authentication checking while importing app resources

### DIFF
--- a/src/Command/Import/App.php
+++ b/src/Command/Import/App.php
@@ -1,15 +1,16 @@
 <?php
 
 namespace Horde\Hordectl\Command\Import;
-use \Horde_Cli_Modular_Module as Module;
-use \Horde_Cli_Modular_ModuleUsage as ModuleUsage;
-use \Horde\Hordectl\HordectlModuleTrait as ModuleTrait;
+
+use Horde_Cli_Modular_Module as Module;
+use Horde_Cli_Modular_ModuleUsage as ModuleUsage;
+use Horde\Hordectl\HordectlModuleTrait as ModuleTrait;
+
 /**
  *
  * Import command module for Horde App provided resources
  */
-class App
-implements Module, ModuleUsage
+class App implements Module, ModuleUsage
 {
     use ModuleTrait;
     public function __construct(\Horde_Injector $dependencies)
@@ -23,6 +24,8 @@ implements Module, ModuleUsage
 
     public function import(string $app, string $resource, array $tree)
     {
+        // This is needed if the import of this resource requires calls to a Horde_Registry_Api class
+        $this->dependencies->getInstance('Horde_Registry')->setAuthenticationSetting('none');
         // Break out to apps to decide if we handle this.
         $apps = $this->dependencies->getRegistryApplications();
         if ($app == 'builtin') {


### PR DESCRIPTION
Some resources require additional api calls to be imported. For some reason this will throw an authentication error `Guest user is not authorized for $host (Local) (Host: ).#0`.

One way to fix this would be to call `Horde_Registry::setAuthenticationSetting('none')` before trying to import app resources.

I did not see any problematic side effects with this approach yet.